### PR TITLE
Add configs for finer grids

### DIFF
--- a/share/ecwam/scripts/ecwam_run_model.sh
+++ b/share/ecwam/scripts/ecwam_run_model.sh
@@ -78,8 +78,8 @@ done
 
 nproma=$(read_config nproma --default=24)
 
-idelpro=$(read_config physics.timestep --format=seconds --default=900)
-idelt=$(read_config advection.timestep --format=seconds --default=900)
+phys_tstp=$(read_config physics.timestep --format=seconds --default=900)
+adv_tstp=$(read_config advection.timestep --format=seconds --default=900)
 
 if [[ $(read_config forcings.sea_ice --default=True) == "True" ]] ; then
   licerun=T
@@ -187,10 +187,10 @@ cat > wam_namelist << EOF
   CBPLTDT               = "${begofrn}",
   CEPLTDT               = "${endofrn}",
   CDATEF                = "${begoffo}",
-  DELPRO_LF             = ${idelpro},
+  DELPRO_LF             = ${adv_tstp},
   IFRELFMAX             = 0,
-  IDELPRO               = ${idelpro},
-  IDELT                 = ${idelt},
+  IDELPRO               = ${phys_tstp},
+  IDELT                 = ${phys_tstp},
   IDELINT               = ${ppfreq},
   IREST                 = 1,
   LFDBIOOUT             = F,

--- a/share/ecwam/scripts/ecwam_run_model.sh
+++ b/share/ecwam/scripts/ecwam_run_model.sh
@@ -80,6 +80,7 @@ nproma=$(read_config nproma --default=24)
 
 phys_tstp=$(read_config physics.timestep --format=seconds --default=900)
 adv_tstp=$(read_config advection.timestep --format=seconds --default=900)
+ifrelfmax=$(read_config ifrelfmax --default=0)
 
 if [[ $(read_config forcings.sea_ice --default=True) == "True" ]] ; then
   licerun=T
@@ -188,7 +189,7 @@ cat > wam_namelist << EOF
   CEPLTDT               = "${endofrn}",
   CDATEF                = "${begoffo}",
   DELPRO_LF             = ${adv_tstp},
-  IFRELFMAX             = 0,
+  IFRELFMAX             = ${ifrelfmax},
   IDELPRO               = ${phys_tstp},
   IDELT                 = ${phys_tstp},
   IDELINT               = ${ppfreq},

--- a/share/ecwam/scripts/ecwam_run_model.sh
+++ b/share/ecwam/scripts/ecwam_run_model.sh
@@ -78,9 +78,21 @@ done
 
 nproma=$(read_config nproma --default=24)
 
+# read timesteps
 phys_tstp=$(read_config physics.timestep --format=seconds --default=900)
-adv_tstp=$(read_config advection.timestep --format=seconds --default=900)
-ifrelfmax=$(read_config ifrelfmax --default=0)
+adv_base_tstp=$(read_config advection.timestep --format=seconds --default=900)
+adv_fast_tstp=$(read_config advection.fast_waves.timestep --format=seconds --default=$adv_base_tstp)
+ifrelfmax=$(read_config advection.fast_waves.max_frequency --default=0)
+
+# verify timesteps
+if [ $(( $adv_base_tstp%$adv_fast_tstp )) -ne 0 ] ; then
+   echo "ERROR: Base advection timestep should be a multiple of fast-wave advection timestep"
+   exit 4
+fi
+if [ $(( $phys_tstp%$adv_base_tstp )) -ne 0 ] ; then
+   echo "ERROR: Physics timestep should be a multiple of base advection timestep"
+   exit 4
+fi
 
 if [[ $(read_config forcings.sea_ice --default=True) == "True" ]] ; then
   licerun=T
@@ -188,9 +200,9 @@ cat > wam_namelist << EOF
   CBPLTDT               = "${begofrn}",
   CEPLTDT               = "${endofrn}",
   CDATEF                = "${begoffo}",
-  DELPRO_LF             = ${adv_tstp},
+  DELPRO_LF             = ${adv_fast_tstp},
   IFRELFMAX             = ${ifrelfmax},
-  IDELPRO               = ${phys_tstp},
+  IDELPRO               = ${adv_base_tstp},
   IDELT                 = ${phys_tstp},
   IDELINT               = ${ppfreq},
   IREST                 = 1,

--- a/tests/etopo1_oper_an_fc_O1280.yml
+++ b/tests/etopo1_oper_an_fc_O1280.yml
@@ -4,11 +4,12 @@ frequencies: 29
 bathymetry:  ETOPO1
 
 advection:
-    timestep: 225
-physics:
     timestep: 450
-
-ifrelfmax: 5
+    fast_waves:
+        timestep: 225
+        max_frequency: 5
+physics:
+    timestep: 900
 
 analysis.begin: 2022-12-31 12:00:00
 analysis.end:   2023-01-01 00:00:00
@@ -65,23 +66,22 @@ validation:
     # initial forecast time
     - name: swh
       time: 2023-01-01 00:00:00
-      average: 0.1447608698613651E+01
-      relative_tolerance: 1.e-14
-      hashes: [0x3FF72967BD1F3649]
+      average: 0.1456589300993350E+01
+      hashes: [0x3FF74E30953784E0]
 
     # 6h into forcast
     - name: swh
       time: 2023-01-01 06:00:00
-      average: 0.1524919757209909E+01
+      average: 0.1532376268424686E+01
       relative_tolerance: 1.e-14
-      hashes: [0x3FF866124263DA64]
+      hashes: [0x3FF8849CFA60CF05]
     - name: swh
       time: 2023-01-01 06:00:00
-      minimum: 0.1720962714224267E-01
+      minimum: 0.1720965670282631E-01
       relative_tolerance: 1.e-14
-      hashes: [0x3F919F6687025752]
+      hashes: [0x3F919F6882DB29B0]
     - name: swh
       time: 2023-01-01 06:00:00
-      maximum: 0.7692948689575956E+01
+      maximum: 0.7669986535925322E+01
       relative_tolerance: 1.e-14
-      hashes: [0x401EC594575E239F]
+      hashes: [0x401EAE10F3523D04]

--- a/tests/etopo1_oper_an_fc_O1280.yml
+++ b/tests/etopo1_oper_an_fc_O1280.yml
@@ -8,6 +8,8 @@ advection:
 physics:
     timestep: 450
 
+ifrelfmax: 5
+
 analysis.begin: 2022-12-31 12:00:00
 analysis.end:   2023-01-01 00:00:00
 forecast.begin: 2023-01-01 00:00:00
@@ -51,3 +53,35 @@ output:
 
 validation:
 
+  double_precision:
+
+    # initial analysis time
+    - name: swh
+      time: 2022-12-31 12:00:00
+      average: 0.1285755868651114E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x3FF49274BEE7F21B]
+
+    # initial forecast time
+    - name: swh
+      time: 2023-01-01 00:00:00
+      average: 0.1447608698613651E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x3FF72967BD1F3649]
+
+    # 6h into forcast
+    - name: swh
+      time: 2023-01-01 06:00:00
+      average: 0.1524919757209909E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x3FF866124263DA64]
+    - name: swh
+      time: 2023-01-01 06:00:00
+      minimum: 0.1720962714224267E-01
+      relative_tolerance: 1.e-14
+      hashes: [0x3F919F6687025752]
+    - name: swh
+      time: 2023-01-01 06:00:00
+      maximum: 0.7692948689575956E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x401EC594575E239F]

--- a/tests/etopo1_oper_an_fc_O1280.yml
+++ b/tests/etopo1_oper_an_fc_O1280.yml
@@ -1,0 +1,53 @@
+grid:        O1280
+directions:  36
+frequencies: 29
+bathymetry:  ETOPO1
+
+advection:
+    timestep: 225
+physics:
+    timestep: 450
+
+analysis.begin: 2022-12-31 12:00:00
+analysis.end:   2023-01-01 00:00:00
+forecast.begin: 2023-01-01 00:00:00
+forecast.end:   2023-01-01 06:00:00
+
+begin: ${analysis.begin}
+end:   ${forecast.end}
+
+nproma: 24
+
+forcings:
+    file:  data/forcings/oper_an_12h_fc_2023010100_36h_O1280.grib
+
+    at:
+      - begin:     ${analysis.begin}
+        end:       ${analysis.end}
+        timestep:  06:00
+      - begin:     ${forecast.begin}
+        end:       ${forecast.end}
+        timestep:  01:00
+
+output:
+    fields:
+        name:
+          - swh         # Significant height of combined wind waves and swell
+          - mwd         # Mean wave direction
+          - mwp         # Mean wave period
+          - pp1d        # Peak wave period
+          - dwi         # 10 metre wind direction
+          - cdww        # Coefficient of drag with waves
+          - wind        # 10 metre wind speed
+        format: grib    # (default : grib) or binary
+        at:
+          - timestep: 01:00
+
+    restart:
+        format: binary # (default : binary) or grib
+        at:
+          - time: ${end}
+
+
+validation:
+

--- a/tests/etopo1_oper_an_fc_O640.yml
+++ b/tests/etopo1_oper_an_fc_O640.yml
@@ -1,0 +1,53 @@
+grid:        O640
+directions:  36
+frequencies: 29
+bathymetry:  ETOPO1
+
+advection:
+    timestep: 450
+physics:
+    timestep: 450
+
+analysis.begin: 2022-12-31 12:00:00
+analysis.end:   2023-01-01 00:00:00
+forecast.begin: 2023-01-01 00:00:00
+forecast.end:   2023-01-01 06:00:00
+
+begin: ${analysis.begin}
+end:   ${forecast.end}
+
+nproma: 24
+
+forcings:
+    file:  data/forcings/oper_an_12h_fc_2023010100_36h_O640.grib
+
+    at:
+      - begin:     ${analysis.begin}
+        end:       ${analysis.end}
+        timestep:  06:00
+      - begin:     ${forecast.begin}
+        end:       ${forecast.end}
+        timestep:  01:00
+
+output:
+    fields:
+        name:
+          - swh         # Significant height of combined wind waves and swell
+          - mwd         # Mean wave direction
+          - mwp         # Mean wave period
+          - pp1d        # Peak wave period
+          - dwi         # 10 metre wind direction
+          - cdww        # Coefficient of drag with waves
+          - wind        # 10 metre wind speed
+        format: grib    # (default : grib) or binary
+        at:
+          - timestep: 01:00
+
+    restart:
+        format: binary # (default : binary) or grib
+        at:
+          - time: ${end}
+
+
+validation:
+

--- a/tests/etopo1_oper_an_fc_O640.yml
+++ b/tests/etopo1_oper_an_fc_O640.yml
@@ -51,3 +51,35 @@ output:
 
 validation:
 
+  double_precision:
+
+    # initial analysis time
+    - name: swh
+      time: 2022-12-31 12:00:00
+      average: 0.1285046301316225E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x3FF48F8CB5DFFBB2]
+
+    # initial forecast time
+    - name: swh
+      time: 2023-01-01 00:00:00
+      average: 0.1450281539835982E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x3FF7345A6A7968B6]
+
+    # 6h into forcast
+    - name: swh
+      time: 2023-01-01 06:00:00
+      average: 0.1528345198537696E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x3FF8741A184B7D10]
+    - name: swh
+      time: 2023-01-01 06:00:00
+      minimum: 0.1726014660228352E-01
+      relative_tolerance: 1.e-14
+      hashes: [0x3F91ACA4D4B9510C]
+    - name: swh
+      time: 2023-01-01 06:00:00
+      maximum: 0.7616349300514687E+01
+      relative_tolerance: 1.e-14
+      hashes: [0x401E772445627E03]


### PR DESCRIPTION
This PR adds configs, including validation norms, for `O640` and `O1280` grids. A small fix to the ecwam runner script, needed to run the `O1280` config, is also included.