### PR TITLE
Update macos CI runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,11 +85,11 @@ jobs:
 
           - name: macos
             # Xcode compiler requires empty environment variables, so we pass null (~) here
-            os: macos-11
-            compiler: clang-12
+            os: macos-13
+            compiler: clang-14
             compiler_cc: ~
             compiler_cxx: ~
-            compiler_fc: gfortran-11
+            compiler_fc: gfortran-13
             caching: true
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
A very small PR to update the macos CI runner, like how it was recently done in ectrans: https://github.com/ecmwf-ifs/ectrans/commit/f77550c15d5672560de0a9f5f0daf9fc19bee9c8