### PR TITLE
Propagate acc link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ ecbuild_add_option( FEATURE LOKI
                     REQUIRED_PACKAGES "loki" )
 
 # Set default Loki transformation mode
-set( LOKI_MODE "scc-hoist" CACHE STRING "Transformation mode for Loki source transformations" )
+set( LOKI_MODE "scc-stack" CACHE STRING "Transformation mode for Loki source transformations" )
 
 ### OpenACC
 if( ${CMAKE_VERSION} VERSION_LESS "3.25" AND HAVE_LOKI AND NOT LOKI_MODE MATCHES "idem|idem-stack" )

--- a/src/ecwam/CMakeLists.txt
+++ b/src/ecwam/CMakeLists.txt
@@ -454,7 +454,8 @@ ecwam_target_fortran_module_directory(
     INSTALL_DIRECTORY module/${ecwam}
 )
 
-if( HAVE_ACC )
+if( HAVE_ACC AND CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC")
+   target_link_options( ${ecwam} INTERFACE SHELL:${OpenACC_Fortran_FLAGS} )
    target_compile_options( ${ecwam} PRIVATE "-gpu=maxregcount:128" )
 endif()
 

--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach( program
     ecbuild_add_executable(
         TARGET          ${PROJECT_NAME}-${program}
         SOURCES         ${program}.F90
-        LIBS            ${PROJECT_NAME} ${OpenMP_Fortran_LIBRARIES} $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
+        LIBS            ${PROJECT_NAME} ${OpenMP_Fortran_LIBRARIES}
         LINKER_LANGUAGE Fortran
     )
     ecwam_target_compile_definitions_FILENAME(${PROJECT_NAME}-${program})


### PR DESCRIPTION
ecWAM did not propagate OpenACC flags to the executable. This was previously masked by the fact that ifs-source would always compile with OpenACC for nvhpc builds. Once I fixed that bug, it exposed the ecWAM bug that this PR fixes.