### PR TITLE
Enable GPU code paths if appropriate Loki transformation is used

### DIFF
--- a/cmake/ecwam_expand_drv_types.cmake
+++ b/cmake/ecwam_expand_drv_types.cmake
@@ -18,7 +18,7 @@ macro( ecwam_expand_drv_types )
       list(APPEND FYPP_ARGS -DPARKIND1_SINGLE_NEMO)
    endif()
 
-   if( HAVE_ACC )
+   if( HAVE_LOKI AND NOT LOKI_MODE MATCHES "idem|idem-stack" )
       list(APPEND FYPP_ARGS -DWAM_GPU)
    endif()
 


### PR DESCRIPTION
A small bug fix to fix failing Loki CI tests.