### PR TITLE
Update nvhpc version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         name:
           - linux gnu-10
           - linux gnu-14
-          - linux nvhpc-21.9
+          - linux nvhpc-23.5
           - linux intel-classic
           - macos
 
@@ -59,15 +59,15 @@ jobs:
             python-version: '3.11'
             caching: true
 
-          - name: linux nvhpc-21.9
+          - name: linux nvhpc-23.5
             os: ubuntu-20.04
-            compiler: nvhpc-21.9
+            compiler: nvhpc-23.5
             compiler_cc: nvc
             compiler_cxx: nvc++
             compiler_fc: nvfortran
             cmake_options: -DCMAKE_CXX_FLAGS=--diag_suppress177
             python-version: '3.8'
-            caching: false
+            caching: true
 
           - name : linux intel-classic
             os: ubuntu-20.04
@@ -136,11 +136,30 @@ jobs:
         path: ${{ env.DEPS_DIR }}
         key: deps-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ env.CACHE_SUFFIX }}
 
+    # Free up disk space for nvhpc
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      if: contains( matrix.compiler, 'nvhpc' )
+      continue-on-error: true
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
+
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
     - name: Install NVHPC compiler
       if: contains( matrix.compiler, 'nvhpc' )
       shell: bash -eux {0}
       run: |
-        ${ECWAM_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc
+        ${ECWAM_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc --version 23.5
         source /opt/nvhpc/env.sh
         echo "${NVHPC_DIR}/compilers/bin"                   >> $GITHUB_PATH
         [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV


### PR DESCRIPTION
The CI nvhpc runners can be fragile. This PR updates the nvhpc version to 23.5, which will hopefully be more robust. The CI push trigger is also removed, as users can manually trigger the CI on specific branches should they need to outside of a PR.