### PR TITLE
Cache subgrid files in preproc

### DIFF
--- a/share/ecwam/scripts/ecwam_runtime.sh
+++ b/share/ecwam/scripts/ecwam_runtime.sh
@@ -11,7 +11,7 @@ SCRIPTS_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd -P )"
 
 # Version of topography result, to be increased when results for same run would be different.
 # e.g. when a bug is fixed.
-export ecwam_bathymetry_version=1
+export ecwam_bathymetry_version=2
 
 ECWAM_CACHE_PATH_DEFAULT=${HOME}/cache/ecwam
 [[ ${HPCPERM} ]] && ECWAM_CACHE_PATH_DEFAULT=${HPCPERM}/cache/ecwam
@@ -55,3 +55,6 @@ export DR_HOOK_ASSERT_MPI_INITIALIZED=0
 
 # export python interpreter
 export ECWAM_PYTHON_INTERP=@ECWAM_PYTHON_INTERP@
+
+# export ecWAM precision
+export ecwam_prec=@prec@

--- a/tests/etopo1_oper_an_fc_O320.yml
+++ b/tests/etopo1_oper_an_fc_O320.yml
@@ -83,3 +83,36 @@ validation:
       maximum: 0.7470872982664355E+01
       relative_tolerance: 1.e-14
       hashes: ['0x401DE22C86F4741A']
+
+  single_precision:
+
+    # initial analysis time
+    - name: swh
+      time: 2022-12-31 12:00:00
+      average: 0.1334386110305786E+01
+      relative_tolerance: 1.e-6
+      hashes: ['0x3FF559A540000000']
+
+    # initial forecast time
+    - name: swh
+      time: 2023-01-01 00:00:00
+      average: 0.1522688865661621E+01
+      relative_tolerance: 1.e-6
+      hashes: ['0x3FF85CEF00000000']
+
+    # 6h into forcast
+    - name: swh
+      time: 2023-01-01 06:00:00
+      average: 0.1602301239967346E+01
+      relative_tolerance: 1.e-6
+      hashes: ['0x3FF9A306A0000000']
+    - name: swh
+      time: 2023-01-01 06:00:00
+      minimum: 0.1733699254691601E-01
+      relative_tolerance: 1.e-6
+      hashes: ['0x3F91C0C9E0000000']
+    - name: swh
+      time: 2023-01-01 06:00:00
+      maximum: 0.7470870018005371E+01
+      relative_tolerance: 1.e-6
+      hashes: ['0x401DE22BC0000000']


### PR DESCRIPTION
The output of the model is very sensitive to the bathymetry and obstruction coefficients. Previously, these were both computed by create_bathymetry, and the resulting bathymetry files were cached in nexus (https://get.ecmwf.int/#browse/browse:ecwam:data%2Fbathymetry%2Fv1%2Fbathymetry_O1280_nfre29_ETOPO1_e6c62ffa77b1815082065ffb241be879.gz). Preproc would then read this bathymetry file and generate the subgrid files. Repeatable results across different compilers and architectures were thus achievable as long as the same bathymetry file was used.

Now that grib output is enabled, create_bathymetry rather than preproc computes the grids, and outputs the subgrid files in grib. Therefore the subgrid files now also have to be cached in nexus in order to get repeatable results across different compilers. This PR makes the necessary changes to the scripts to achieve this.

Right now, I have only uploaded the bathymetry and subgrid files for the O48 grids to nexus. As this is a new caching approach they are in the v2 folder. Older versions of ecwam that don't use grib output will continue to use the bathymetries in the v1 folder. Once the PR is approved I will upload the bathymetries and subgrids for the O320, O640 and O1280 grids too.

This PR also adds single precision validation hashes for the O320 test case.