### PR TITLE
Upgrade Loki to v0.2.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
           ecmwf/fckit@refs/tags/0.13.0
           ecmwf-ifs/fiat@refs/tags/1.4.1
           ecmwf-ifs/field_api@refs/tags/v0.3.1
-          ecmwf-ifs/loki@refs/tags/v0.2.8
+          ecmwf-ifs/loki@refs/tags/v0.2.9
         dependency_branch: develop
         dependency_cmake_options: |
           ecmwf/fckit: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_FCKIT_VENV=ON"

--- a/package/bundle/bundle.yml
+++ b/package/bundle/bundle.yml
@@ -39,7 +39,7 @@ projects :
 
     - loki :
         git     : https://github.com/ecmwf-ifs/loki
-        version : v0.2.8
+        version : v0.2.9
         optional: true
         require : ecbuild
         cmake   : >


### PR DESCRIPTION
A small PR to upgrade Loki to a version containing a critical bug fix.