### PR TITLE
Add ci-hpc plan to Github Actions

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -1,0 +1,138 @@
+name: build-hpc
+
+# Controls when the action will run
+on:
+
+  # Trigger the workflow on all pull requests
+  pull_request: ~
+
+  # Allow workflow to be dispatched on demand
+  workflow_dispatch: ~
+
+env:
+  ECWAM_TOOLS: ${{ github.workspace }}/.github/tools
+  CTEST_PARALLEL_LEVEL: 1
+  CACHE_SUFFIX: v1         # Increase to force new cache to be created
+
+jobs:
+  ci-hpc:
+    name: ci-hpc
+
+    strategy:
+      fail-fast: false    # false: try to complete all jobs
+
+      matrix:
+        name:
+          - ac-gpu nvhpc sp
+
+        include:
+          - name: ac-gpu nvhpc sp
+            site: ac-batch
+            sbatch_options: |
+              #SBATCH --time=00:20:00
+              #SBATCH --nodes=1
+              #SBATCH --ntasks=4
+              #SBATCH --cpus-per-task=32
+              #SBATCH --gpus-per-task=1
+              #SBATCH --mem=0
+              #SBATCH --qos=dg
+
+    runs-on: [self-hosted, linux, hpc]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+        with:
+          site: ${{ matrix.site }}
+          troika_user: ${{ secrets.HPC_CI_SSH_USER }}
+          sbatch_options: ${{ matrix.sbatch_options }}
+          template_data: |
+            modules:
+              - cmake
+              - fcm
+              - ninja
+              - ecbuild
+              - prgenv/nvidia
+              - hpcx-openmpi/2.14.0-cuda
+              - python3
+            cmake_options:
+              - -DENABLE_MPI=ON
+              - -DENABLE_LOKI=ON
+              - -DENABLE_ACC=ON
+              - -DENABLE_CUDA=ON
+              - -DENABLE_GPU_AWARE_MPI=ON
+              - -DENABLE_SINGLE_PRECISION=ON
+            dependencies:
+              ecmwf/eccodes:
+                version: develop
+                cmake_options:
+                  - -DENABLE_MEMFS=ON
+                  - -DENABLE_JPG=OFF
+                  - -DENABLE_PNG=OFF
+              ecmwf/fckit:
+                version: 0.13.0
+                cmake_options:
+                  - -DENABLE_TESTS=OFF
+                  - -DENABLE_FCKIT_VENV=ON
+              ecmwf-ifs/fiat:
+                version: 1.4.1
+                cmake_options:
+                  - -DENABLE_MPI=ON
+                  - -DENABLE_SINGLE_PRECISION=ON
+                  - -DENABLE_DOUBLE_PRECISION=OFF
+              ecmwf-ifs/field_api:
+                version: v0.3.1
+                cmake_options:
+                  - -DENABLE_TESTS=OFF
+                  - -DENABLE_ACC=ON
+                  - -DENABLE_CUDA=ON
+                  - -DENABLE_SINGLE_PRECISION=ON
+                  - -DENABLE_DOUBLE_PRECISION=OFF
+              ecmwf-ifs/loki:
+                version: v0.2.9
+                cmake_options:
+                  - -DENABLE_TESTS=OFF
+          template: |
+            {% for module in modules %}
+              module load {{module}}
+            {% endfor %}
+
+            BASEDIR=$PWD
+
+            {% for name, options in dependencies.items() %}
+                mkdir -p {{name}}
+                pushd {{name}}
+
+                git init
+                git remote add origin ${{ github.server_url }}/{{name}}
+                git fetch origin {{options['version']}}
+                git reset --hard FETCH_HEAD
+
+                cmake -G Ninja -S . -B build \
+                  {% for name in dependencies %}
+                    {% set org, proj = name.split('/') %}
+                    -D{{proj}}_ROOT=$BASEDIR/{{name}}/installation \
+                  {% endfor %}
+                  {{ options['cmake_options']|join(' ') }}
+                cmake --build build
+                cmake --install build --prefix installation
+                popd
+            {% endfor %}
+
+            mkdir -p ${{ github.repository }}
+            pushd ${{ github.repository }}
+            git init
+            git remote add origin ${{ github.server_url }}/${{ github.repository }}
+            git fetch origin ${{ github.sha }}
+            git reset --hard FETCH_HEAD
+            popd
+
+            cmake -G Ninja -S ${{ github.repository }} -B build \
+              {% for name in dependencies %}
+                {% set org, proj = name.split('/') %}
+                -D{{proj}}_ROOT=$BASEDIR/{{name}}/installation \
+              {% endfor %}
+              {{ cmake_options|join(' ') }}
+
+            cmake --build build
+            ctest --test-dir build


### PR DESCRIPTION
This adds a new Github Actions workflow that dispatches to our HPC and builds and runs ecwam on GPUs.