### PR TITLE
Loki: Remove deprecated `DIRECTIVE` option in Loki CMake macro call

### DIFF
--- a/src/ecwam/CMakeLists.txt
+++ b/src/ecwam/CMakeLists.txt
@@ -515,7 +515,6 @@ if( HAVE_LOKI )
   # Apply Loki source file transformation to lib target
   loki_transform_target( TARGET ${ecwam}
     MODE ${LOKI_MODE}
-    DIRECTIVE openacc
     FRONTEND ${LOKI_FRONTEND}
     CONFIG ${LOKI_CONFIG_FILE}
     PLAN ${CMAKE_CURRENT_BINARY_DIR}/loki_plan_ecwam.cmake


### PR DESCRIPTION
This is about to be removed upstream as part of the entry-point clean-up.