### PR TITLE
Open input files with read-only rather than readwrite to prevent lock storms

### DIFF
--- a/src/ecwam/wvwaminit.F90
+++ b/src/ecwam/wvwaminit.F90
@@ -164,7 +164,7 @@
           CALL WAM_ABORT("WAVE MODEL INPUT FILE '"//FILENAME(1:LFILE)//"' IS MISSING !!!",&
                         &__FILENAME__,__LINE__)
         ENDIF
-        IU07 = IWAM_GET_UNIT(IU06, FILENAME(1:LFILE) , 'r', 'u',0,'READWRITE')
+        IU07 = IWAM_GET_UNIT(IU06, FILENAME(1:LFILE) , 'r', 'u',0,'READ')
 
         IF (IPROPAGS < 0 .OR. IPROPAGS > NPROPAGS) THEN
           WRITE(IU06,*) '************************************'
@@ -195,7 +195,7 @@
           CALL WAM_ABORT("WAVE MODEL INPUT FILE '"//FILENAME(1:LFILE)//"' IS MISSING !!!",&
                         &__FILENAME__,__LINE__)
         ENDIF
-        IU08(IPROPAGS) = IWAM_GET_UNIT(IU06, FILENAME(1:LFILE),'r','u',0,'READWRITE')
+        IU08(IPROPAGS) = IWAM_GET_UNIT(IU06, FILENAME(1:LFILE),'r','u',0,'READ')
       ENDIF
 
       KTAG=1


### PR DESCRIPTION
When run in coupled mode, we open wam_grid_tables and other binary files as readwrite even though we only read from them. This can cause lock storms as in some places we do this operation with all tasks and also prevents sharing of inputs since we need to set rw permissions for groups or others. If run in standalone mode, where some of these files are written to, the open semantics does not change.