### PR TITLE
Fix name of develop branch in pr-check workflow (was staging)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
-name: Check Pull Request
+name: check-pr
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [ main, develop ]
 
@@ -16,6 +16,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -31,6 +33,6 @@ jobs:
 
       - name: Assign reviewers
         env:
-          GITHUB_TOKEN: ${{ secrets.MODIFY_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           prtk assign-reviewers --pr-number ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,7 +3,7 @@ name: Check Pull Request
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ main, staging ]
+    branches: [ main, develop ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Sorry @awnawab - I didn't spot that I was using `staging` as the branch name in the workflow file, whereas the branch name in this repo is `develop`.