### PR TITLE
Pin ecbuild to 3.10.0 to fix failing CI

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -106,7 +106,7 @@ jobs:
                   - -DENABLE_FCKIT_VENV=ON
                   - -DBUILD_SHARED_LIBS=${{ !matrix.gpu }}
               ecmwf-ifs/fiat:
-                version: 1.4.1
+                version: 1.5.1
                 cmake_options:
                   - -DENABLE_MPI=ON
                   - -DENABLE_SINGLE_PRECISION=ON

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -49,7 +49,7 @@ jobs:
               - ecbuild
               - prgenv/nvidia
               - hpcx-openmpi/2.14.0-cuda
-              - python3
+              - python3/3.11.10-01 
             gpu: 1
 
           - name: ac-cpu intel sp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
           ecmwf/ecbuild
           ecmwf/eccodes
           ecmwf/fckit@refs/tags/0.13.0
-          ecmwf-ifs/fiat@refs/tags/1.4.1
+          ecmwf-ifs/fiat@refs/tags/1.5.1
           ecmwf-ifs/field_api@refs/tags/v0.3.1
           ecmwf-ifs/loki@refs/tags/v0.2.9
         dependency_branch: develop

--- a/package/bundle/bundle.yml
+++ b/package/bundle/bundle.yml
@@ -29,7 +29,7 @@ projects :
 
     - fiat :
         git     : https://github.com/ecmwf-ifs/fiat 
-        version : 1.4.1
+        version : 1.5.1
 
     - field_api :
         git     : https://github.com/ecmwf-ifs/field_api.git
@@ -89,7 +89,7 @@ options :
     - with-gpu-aware-mpi :
         help  : Enable direct GPU-to-GPU MPI communications
         cmake : ENABLE_GPU_AWARE_MPI=ON
-       
+
     - loki-mode :
         help  : Choose Loki transformation (defaults to scc-stack)
         cmake : LOKI_MODE={{value}}


### PR DESCRIPTION
One of the recent merges to ecbuild broke ifort builds. This PR pins the version of ecbuild used in the CI to the last point release whilst the ecbuild bug is investigated further.