### PR TITLE
Adding mars stream clte  option

### DIFF
--- a/src/ecwam/wstream_strg.F90
+++ b/src/ecwam/wstream_strg.F90
@@ -528,6 +528,12 @@
         MARSFCTYPE = 'fc'
         KSTREAM = 1248
         LASTREAM=.TRUE.
+      ELSE IF(ISTREAM.EQ.1098) THEN
+!       WAVE DESTINE FORECAST
+        CSTREAM = 'clte'
+        MARSFCTYPE = 'fc'
+        KSTREAM = 1098
+        LASTREAM=.TRUE.
       ELSE IF(ISTREAM.EQ.1091) THEN
 !       WAVE SEASONAL MONTHLY MEANS
         CSTREAM = 'sfmm'


### PR DESCRIPTION
This commit enables destine experiments to be setup with the correct stream settings and avoids doing this in postprocessing. As part of the grib migration IFS streams and wave streams will be identical. This was already applied in Destine, therefore the clte stream ISTREAM does map to the same KSTREAM. 

Up until know every case here sets also the LASTREAM variable, which is now misleading as they are both IFS stream and Wave stream. 