### PR TITLE
Switch to SCCVec transformation

### DIFF
--- a/src/ecwam/ecwam_loki_gpu.config
+++ b/src/ecwam/ecwam_loki_gpu.config
@@ -70,7 +70,7 @@ block = ['ec_parkind', 'parkind_wave', 'yowdrvtype',
 # SCC transformations
 [transformations.SCCVectorOpenACC]
   module = "loki.transformations.single_column"
-  classname = "SCCSVectorPipeline"
+  classname = "SCCVectorPipeline"
 [transformations.SCCVectorOpenACC.options]
   horizontal = "%dimensions.horizontal%"
   directive = "openacc"


### PR DESCRIPTION
SCCSeq and SCCVec are the two baseline loki transformations for GPU offload. Although they are both quite slow and would never be used in a proper run, they are a very useful debugging baseline. Of the two, SCCVec is arguably the more useful debugging tool because it doesn't change subroutine interfaces, and therefore if openacc compilation is disabled it can be used effectively to bisect the loki transformed call tree.

This PR switches ecwam to use the SCCVec transformation, bringing it in line with the IFS. SCCSeq also generates unexpected runtime errors for larger grids, these remain to be investigated.