### PR TITLE
Pin eccodes to 2.44.0

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -95,7 +95,7 @@ jobs:
               - -DBUILD_SHARED_LIBS=${{ !matrix.gpu }}
             dependencies:
               ecmwf/eccodes:
-                version: develop
+                version: 2.44.0
                 cmake_options:
                   - -DENABLE_MEMFS=ON
                   - -DENABLE_JPG=OFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
         recreate_cache: ${{ matrix.caching == false }}
         dependencies: |
           ecmwf/ecbuild
-          ecmwf/eccodes
+          ecmwf/eccodes@refs/tags/2.44.0
           ecmwf/fckit@refs/tags/0.13.0
           ecmwf-ifs/fiat@refs/tags/1.5.1
           ecmwf-ifs/field_api@refs/tags/v0.3.4

--- a/package/bundle/bundle.yml
+++ b/package/bundle/bundle.yml
@@ -19,7 +19,7 @@ projects :
 
     - eccodes :
         git     : https://github.com/ecmwf/eccodes
-        version : master
+        version : 2.44.0
         cmake   : ENABLE_MEMFS=ON
 
     - fckit :


### PR DESCRIPTION
This PR pins eccodes to 2.44.0 to workaround issues with finding libaec 1.0.6 in the CI linux runners. Once this is debugged we can resume tracking eccodes master/develop.