### PR TITLE
Set generatingProcessIdentifier via namlist

### DIFF
--- a/src/ecwam/mpuserin.F90
+++ b/src/ecwam/mpuserin.F90
@@ -791,8 +791,8 @@
       ROWATER = 1000.0_JWRB
       GAM_SURF = 0.0717_JWRB
 
-      IMDLGRBID_G = -1 
-      IMDLGRBID_M = -1
+      IMDLGRBID_G = 108 
+      IMDLGRBID_M = 208
 ! ----------------------------------------------------------------------
 
 !*    1. READ NAMELIST NALINE.

--- a/src/ecwam/mpuserin.F90
+++ b/src/ecwam/mpuserin.F90
@@ -488,7 +488,24 @@
 !     ROAIR : DEFAULT VALUES FOR AIR DENSITY (kg m**-3)
 !     ROWATER : DEFAULT VALUES FOR WATER DENSITY (kg m**-3)
 !     GAM_SURF : DEFAUT VALUE FOR WATER SURFACE TENSION (in N/m)
+!     IMDLGRBID_G: GLOBAL MODEL IDENTIFICATION FOR GRIB CODING
+!     IMDLGRBID_M: LAW MODEL IDENTIFICATION FOR GRIB CODING
+! 
+! The generating process identification numbers (model numbers IMDLGRBID_G/IMDLGRBID_M) 
+! for GRIB headers are allocated in pre-defined ranges for ECMWF GRIB coded
+! fields. The field in the GRIB code for this number is 1 octet and with
+! the value 255 indicating 'missing value', only numbers 1-254 are
+! available for use.
+! The atmospheric model allocated numbers are in the range 121 to 203.
+! The Global wave model allocated numbers are in the range 104 to 120.
+! The LAW model allocated numbers are in the range 204 to 220.
+! The numbers 221 to 254 stay reserved for the moment.
+! This pre-allocation was introduced to enable some Member States, which
+! use the model number to identify products, to write their software in
+! such a way that model number changes did not cause them problems with
+! hard-coded model numbers. 
 
+      
 
 !     NAMELIST NAOT : 
 !     ===============
@@ -774,7 +791,7 @@
       ROWATER = 1000.0_JWRB
       GAM_SURF = 0.0717_JWRB
 
-      IMDLGRBID_G = -1
+      IMDLGRBID_G = -1 
       IMDLGRBID_M = -1
 ! ----------------------------------------------------------------------
 
@@ -1056,6 +1073,8 @@
         WRITE(6,*) '*** ROAIR = ',ROAIR
         WRITE(6,*) '*** ROWATER = ',ROWATER
         WRITE(6,*) '*** GAM_SURF = ',GAM_SURF
+        WRITE(6,*) '*** IMDLGRBID_G = ',IMDLGRBID_G
+        WRITE(6,*) '*** IMDLGRBID_M = ',IMDLGRBID_M
         IF (NGOUT > 0) THEN
           WRITE (6,*) " OUTPUT POINTS FOR SPECTRA AS DEFINED BY USER INPUT    NO.    LAT.   LONG. "
           DO IC=1,NGOUT

--- a/src/ecwam/mpuserin.F90
+++ b/src/ecwam/mpuserin.F90
@@ -75,7 +75,7 @@
       USE YOWCURR  , ONLY : IDELCUR  ,CDATECURA, LLCFLCUROFF
       USE YOWFPBO  , ONLY : IBOUNF
       USE YOWFRED  , ONLY : IFRE1, FR1, XKMSS_CUTOFF 
-      USE YOWGRIBHD, ONLY : LGRHDIFS,                                   &
+      USE YOWGRIBHD, ONLY : LGRHDIFS, IMDLGRBID_G, IMDLGRBID_M,         &
      &                      LNEWLVTP, LL_GRID_SIMPLE_MATRIX, LLRSTGRIBPARAM
       USE YOWGRIB_HANDLES , ONLY : NGRIB_HANDLE_IFS
       USE YOWGRID  , ONLY : NPROMA_WAM
@@ -237,7 +237,8 @@
      &   LLCAPCHNK, LLGCBZ0, LLNORMAGAM,                                &
      &   LWAM_USE_IO_SERV,                                              &
      &   LOUTMDLDCP,                                                    &
-     &   ROAIR, ROWATER, GAM_SURF
+     &   ROAIR, ROWATER, GAM_SURF,                                      &
+     &   IMDLGRBID_G, IMDLGRBID_M
 
 
       CHARACTER(LEN=14) :: CLOUT
@@ -773,6 +774,8 @@
       ROWATER = 1000.0_JWRB
       GAM_SURF = 0.0717_JWRB
 
+      IMDLGRBID_G = -1
+      IMDLGRBID_M = -1
 ! ----------------------------------------------------------------------
 
 !*    1. READ NAMELIST NALINE.

--- a/src/ecwam/userin.F90
+++ b/src/ecwam/userin.F90
@@ -473,16 +473,28 @@ SUBROUTINE USERIN (IFORCA, LWCUR)
         LFDBIOOUT=.FALSE.
       ENDIF
 
-      IF (IMDLGRBID_M < 0 .OR. IMDLGRBID_G < 0) THEN
+      IF (IMDLGRBID_M < 204 .OR. IMDLGRBID_M > 220) THEN
         WRITE(IU06,*)'++++++++++++++++++++++++++++++++++++++++++++++++++'
         WRITE(IU06,*)'+                                                +'
         WRITE(IU06,*)'+ SUBROUTINE USERIN :                            +'
         WRITE(IU06,*)'+ READ NAMELIST FAILED                           +'
-        WRITE(IU06,*)'+ IMDLGRBID_M and IMDLGRBID_G MUST BE SPECIFIED  +'
+        WRITE(IU06,*)'+ IMDLGRBID_M MUST BE IN THE RANGE 204 - 220     +'
         WRITE(IU06,*)'+ PROGRAM WILL ABORT                             +'
         WRITE(IU06,*)'+                                                +'
         WRITE(IU06,*)'++++++++++++++++++++++++++++++++++++++++++++++++++'
-        CALL WAM_ABORT("Expected namelist input for IMDLGRBID_M and IMDLGRBID_G",__FILENAME__,__LINE__)
+        CALL WAM_ABORT("Unexpected namelist input for IMDLGRBID_M",__FILENAME__,__LINE__)
+      ENDIF
+
+      IF (IMDLGRBID_G < 104 .OR. IMDLGRBID_G > 120) THEN
+        WRITE(IU06,*)'++++++++++++++++++++++++++++++++++++++++++++++++++'
+        WRITE(IU06,*)'+                                                +'
+        WRITE(IU06,*)'+ SUBROUTINE USERIN :                            +'
+        WRITE(IU06,*)'+ READ NAMELIST FAILED                           +'
+        WRITE(IU06,*)'+ IMDLGRBID_G MUST BE IN THE RANGE 104 - 120     +'
+        WRITE(IU06,*)'+ PROGRAM WILL ABORT                             +'
+        WRITE(IU06,*)'+                                                +'
+        WRITE(IU06,*)'++++++++++++++++++++++++++++++++++++++++++++++++++'
+        CALL WAM_ABORT("Unexpected namelist input for IMDLGRBID_G",__FILENAME__,__LINE__)
       ENDIF
 
 !*    1.1  READ THE WAMINFO FILE AND OVERWRITE INPUT.

--- a/src/ecwam/userin.F90
+++ b/src/ecwam/userin.F90
@@ -473,6 +473,18 @@ SUBROUTINE USERIN (IFORCA, LWCUR)
         LFDBIOOUT=.FALSE.
       ENDIF
 
+      IF (IMDLGRBID_M < 0 .OR. IMDLGRBID_G < 0) THEN
+        WRITE(IU06,*)'++++++++++++++++++++++++++++++++++++++++++++++++++'
+        WRITE(IU06,*)'+                                                +'
+        WRITE(IU06,*)'+ SUBROUTINE USERIN :                            +'
+        WRITE(IU06,*)'+ READ NAMELIST FAILED                           +'
+        WRITE(IU06,*)'+ IMDLGRBID_M and IMDLGRBID_G MUST BE SPECIFIED  +'
+        WRITE(IU06,*)'+ PROGRAM WILL ABORT                             +'
+        WRITE(IU06,*)'+                                                +'
+        WRITE(IU06,*)'++++++++++++++++++++++++++++++++++++++++++++++++++'
+        CALL WAM_ABORT("Expected namelist input for IMDLGRBID_M and IMDLGRBID_G",__FILENAME__,__LINE__)
+      ENDIF
+
 !*    1.1  READ THE WAMINFO FILE AND OVERWRITE INPUT.
 !          ------------------------------------------
 

--- a/src/ecwam/yowgribhd.F90
+++ b/src/ecwam/yowgribhd.F90
@@ -19,8 +19,8 @@
       CHARACTER(LEN=4), PARAMETER :: CEXPVERCLIM='0001'  !! reference expver for wave climate fields (see *preproc*) 
       INTEGER(KIND=JWIM), PARAMETER :: KPARAM_SUBGRIG=219 !! parameter id of the model bathymetry to insure the same interpolation method
                                                           !! is used for the sub grid obstruction coeeficient
-      INTEGER(KIND=JWIM), PARAMETER :: IMDLGRBID_G=107 !! see below the rule on how to select IMDLGRBID_G
-      INTEGER(KIND=JWIM), PARAMETER :: IMDLGRBID_M=207
+      INTEGER(KIND=JWIM) :: IMDLGRBID_G=107 !! see below the rule on how to select IMDLGRBID_G
+      INTEGER(KIND=JWIM) :: IMDLGRBID_M=207
 
       INTEGER(KIND=JWIM) :: NDATE_TIME_WINDOW_END=0
       INTEGER(KIND=JWIM) :: NWINOFF

--- a/src/ecwam/yowgribhd.F90
+++ b/src/ecwam/yowgribhd.F90
@@ -19,8 +19,8 @@
       CHARACTER(LEN=4), PARAMETER :: CEXPVERCLIM='0001'  !! reference expver for wave climate fields (see *preproc*) 
       INTEGER(KIND=JWIM), PARAMETER :: KPARAM_SUBGRIG=219 !! parameter id of the model bathymetry to insure the same interpolation method
                                                           !! is used for the sub grid obstruction coeeficient
-      INTEGER(KIND=JWIM) :: IMDLGRBID_G=107 !! see below the rule on how to select IMDLGRBID_G
-      INTEGER(KIND=JWIM) :: IMDLGRBID_M=207
+      INTEGER(KIND=JWIM) :: IMDLGRBID_G !! see below the rule on how to select IMDLGRBID_G
+      INTEGER(KIND=JWIM) :: IMDLGRBID_M
 
       INTEGER(KIND=JWIM) :: NDATE_TIME_WINDOW_END=0
       INTEGER(KIND=JWIM) :: NWINOFF
@@ -58,27 +58,9 @@
 !*    VARIABLE.   TYPE.     PURPOSE.
 !     ---------   -------   --------
 !     IMDLGRBID_G INTEGER   GLOBAL MODEL IDENTIFICATION FOR GRIB CODING
-!                           IT CAN ALSO BE MODIFIED IN THE INPUT NAMELIST.
+!                           MUST BE SPECIFIED IN THE INPUT NAMELIST.
 !     IMDLGRBID_M INTEGER   LAW MODEL IDENTIFICATION FOR GRIB CODING
-!                           IT CAN ALSO BE MODIFIED IN THE INPUT NAMELIST.
-! 
-! The generating process identification numbers (model numbers) for GRIB
-! headers are allocated in pre-defined ranges for ECMWF GRIB coded
-! fields. The field in the GRIB code for this number is 1 octet and with
-! the value 255 indicating 'missing value', only numbers 1-254 are
-! available for use.
-
-! The atmospheric model allocated numbers are in the range 121 to 203.
-! The Global wave model allocated numbers are in the range 104 to 120.
-! The LAW model allocated numbers are in the range 204 to 220.
- 
-! The numbers 221 to 254 stay reserved for the moment.
-
-! This pre-allocation was introduced to enable some Member States, which
-! use the model number to identify products, to write their software in
-! such a way that model number changes did not cause them problems with
-! hard-coded model numbers. 
-
+!                           MUST BE SPECIFIED IN THE INPUT NAMELIST.
 !     PPMISS      REAL      ALL SPECTRAL VALUES LESS OR EQUAL PPMISS ARE
 !                           REPLACED BY THE MISSING DATA INDICATOR
 !     PPEPS       REAL      SMALL NUMBER USED IN SPECTRAL PACKING OF 251

--- a/src/ecwam/yowgribhd.F90
+++ b/src/ecwam/yowgribhd.F90
@@ -19,8 +19,8 @@
       CHARACTER(LEN=4), PARAMETER :: CEXPVERCLIM='0001'  !! reference expver for wave climate fields (see *preproc*) 
       INTEGER(KIND=JWIM), PARAMETER :: KPARAM_SUBGRIG=219 !! parameter id of the model bathymetry to insure the same interpolation method
                                                           !! is used for the sub grid obstruction coeeficient
-      INTEGER(KIND=JWIM) :: IMDLGRBID_G !! see below the rule on how to select IMDLGRBID_G
-      INTEGER(KIND=JWIM) :: IMDLGRBID_M
+      INTEGER(KIND=JWIM) :: IMDLGRBID_G=108 
+      INTEGER(KIND=JWIM) :: IMDLGRBID_M=208
 
       INTEGER(KIND=JWIM) :: NDATE_TIME_WINDOW_END=0
       INTEGER(KIND=JWIM) :: NWINOFF


### PR DESCRIPTION
At the moment the generatingProcessIdentifier for the wave model is hardcoded in yowgribhd.F90. With this PR I'd like to switch to instead setting this via namelist variables. 

If accepted, I suggest we propagate this to the main branch for implementation in CY50R1 too, since at the moment the hardcoded values for CY49R2 are being used.

@jrbidlot and/or @jkousal32 it would be great to get your eyes on this.