### PR TITLE
Fix python search

### DIFF
--- a/cmake/ecwam_find_python_mods.cmake
+++ b/cmake/ecwam_find_python_mods.cmake
@@ -8,9 +8,6 @@
 
 macro( ecwam_find_python_mods )
 
-   # Find the system python install
-   set( Python3_FIND_VIRTUALENV STANDARD )
-
    # Look for python interpreter and pyyaml
    find_package( Python3 COMPONENTS Interpreter REQUIRED)
    set(ECWAM_PYTHON_INTERP ${Python3_EXECUTABLE})


### PR DESCRIPTION
A small fix to the python search behaviour, which removes a safeguard only needed for projects that create python virtual environments so is not needed here. This allows for example, building ecWAM by having an active virtual env that has fypp and pyyaml installed.