### PR TITLE
Fix warning on conversion with -r8 flag

### DIFF
--- a/src/ecwam/propconnect.F90
+++ b/src/ecwam/propconnect.F90
@@ -683,7 +683,7 @@ SUBROUTINE PROPCONNECT(IJS, IJL, NEWIJ2IJ)
           I = BLK2GLO%IXLG(IP)
           K = BLK2GLO%KXLT(IP)
           IP1D = NEWIJ2IJ(IP)
-          D0 = FLOAT(I-1)*ZDELLO(K)
+          D0 = REAL(I-1,JWRB)*ZDELLO(K)
           D3=D0-0.5_JWRB*ZDELLO(K)
           D5=D0+0.5_JWRB*ZDELLO(K)
 


### PR DESCRIPTION
The NVHPC Fortran compiler warning:

```
NVFORTRAN-W-0155-The type of FLOAT is now double precision with -r8 (propconnect.F90: 686)
```