### PR TITLE
bugfix for sebtmean and se10mean that are needed fro CY50R1

### DIFF
--- a/src/ecwam/se10mean.F90
+++ b/src/ecwam/se10mean.F90
@@ -47,9 +47,8 @@
 
       USE PARKIND_WAVE, ONLY : JWIM, JWRB, JWRU
 
-      USE YOWFRED  , ONLY : FR       ,DFIM     ,DELTH    ,FLOGSPRDM1
+      USE YOWFRED  , ONLY : FR
       USE YOWPARAM , ONLY : NANG     ,NFRE
-      USE YOWPCONS , ONLY : EPSMIN
 
       USE YOMHOOK  , ONLY : LHOOK,   DR_HOOK, JPHOOK
 
@@ -57,58 +56,22 @@
 
       IMPLICIT NONE
 
+#include "sebtmean.intfb.h"
 
       INTEGER(KIND=JWIM), INTENT(IN) :: KIJS, KIJL
       REAL(KIND=JWRB), DIMENSION(KIJL, NANG, NFRE), INTENT(IN) :: FL1
       REAL(KIND=JWRB), DIMENSION(KIJL), INTENT(OUT) :: E10
 
-
-      INTEGER(KIND=JWIM) :: IJ, M, K, MCUT
-
-      REAL(KIND=JWRB), PARAMETER :: FCUT=0.1_JWRB
-      REAL(KIND=JWRB) :: DFCUT
+      REAL(KIND=JWRB) :: TEWHMIN, TEWHMAX
       REAL(KIND=JPHOOK) :: ZHOOK_HANDLE
-      REAL(KIND=JWRB), DIMENSION(NFRE) :: DFIMLOC
-      REAL(KIND=JWRB), DIMENSION(KIJL) :: TEMP
 
 ! ----------------------------------------------------------------------
 
       IF (LHOOK) CALL DR_HOOK('SE10MEAN',0,ZHOOK_HANDLE)
 
-      MCUT=NINT(LOG10(FCUT/FR(1))*FLOGSPRDM1)+1
-      MCUT=MIN(MAX(1,MCUT),NFRE)
-
-      DFIMLOC(:)=DFIM(:)
-      DFCUT=0.5_JWRB*MAX(0.0_JWRB,FCUT-0.5_JWRB*(FR(MAX(1,MCUT-1))+FR(MCUT)))
-      DFIMLOC(MCUT)=MIN(DFCUT*DELTH,DFIM(MCUT))
-
-
-!*    1. INITIALISE ENERGY ARRAY.
-!        ------------------------
-
-      DO IJ=KIJS,KIJL
-        E10(IJ) = EPSMIN 
-      ENDDO
-
-! ----------------------------------------------------------------------
-
-!*    2. INTEGRATE OVER FREQUENCIES AND DIRECTION.
-!        -----------------------------------------
-
-      DO M=1,MCUT
-        K=1
-        DO IJ=KIJS,KIJL
-          TEMP(IJ) = FL1(IJ,K,M)
-        ENDDO
-        DO K=2,NANG
-          DO IJ=KIJS,KIJL
-            TEMP(IJ) = TEMP(IJ)+FL1(IJ,K,M)
-          ENDDO
-        ENDDO
-        DO IJ=KIJS,KIJL
-          E10(IJ) = E10(IJ)+DFIMLOC(M)*TEMP(IJ)
-        ENDDO
-      ENDDO
+      TEWHMIN = 10.0_JWRB
+      TEWHMAX = 1.0_JWRB / FR(1)
+      CALL SEBTMEAN (KIJS, KIJL, FL1, TEWHMIN, TEWHMAX, E10)
 
       IF (LHOOK) CALL DR_HOOK('SE10MEAN',1,ZHOOK_HANDLE)
 

--- a/src/ecwam/sebtmean.F90
+++ b/src/ecwam/sebtmean.F90
@@ -50,7 +50,7 @@
 
       USE PARKIND_WAVE, ONLY : JWIM, JWRB, JWRU
 
-      USE YOWFRED  , ONLY : FR, FR5, DFIM, DELTH, FLOGSPRDM1
+      USE YOWFRED  , ONLY : FR, FR5, DELTH
       USE YOWPARAM , ONLY : NANG, NFRE
       USE YOWPCONS , ONLY : EPSMIN
 
@@ -68,35 +68,36 @@
 
       INTEGER(KIND=JWIM) :: IJ, M, K, MCUTB, MCUTT
 
-      REAL(KIND=JWRB) :: FCUTB, FCUTT, DFCUT, FBOT, FTOP, ZW
+      REAL(KIND=JWRB) :: FCUTB, FCUTB_FT, FCUTT, FBOT, FTOP, ZW
+      REAL(KIND=JWRB) :: WL, WR, DF
       REAL(KIND=JPHOOK) :: ZHOOK_HANDLE
-      REAL(KIND=JWRB), DIMENSION(NFRE) :: DFIMLOC
-      REAL(KIND=JWRB), DIMENSION(KIJL) :: TEMP
+      REAL(KIND=JWRB), DIMENSION(NFRE) :: FRLOC 
+      REAL(KIND=JWRB), DIMENSION(KIJL,NFRE) :: F1D 
 
 ! ----------------------------------------------------------------------
 
       IF (LHOOK) CALL DR_HOOK('SEBTMEAN',0,ZHOOK_HANDLE)
 
-      DFIMLOC(:)=DFIM(:)
+      FBOT = 1.0_JWRB/MAX(TT,EPSMIN)
+      FCUTB_FT = MIN(FBOT,FR(NFRE))
+      FCUTB = MAX(FR(1),FCUTB_FT)
+      FBOT = MAX(FBOT,FR(NFRE))   !! FBOT is used if a tail contribution is needed
 
-      FBOT=1.0_JWRB/MAX(TT,EPSMIN)
-      FCUTB=MAX(FR(1),MIN(FBOT,FR(NFRE)))
-      FBOT=MAX(FBOT,FR(NFRE))
+      MCUTB=1
+!i!!!  MCUTB is defined such that the integration will need to be from frequency FRLOC(MAX(MCUTB-1,1))
+      DO WHILE (FR(MCUTB) < FCUTB .AND. MCUTB < NFRE )
+        MCUTB = MCUTB+1
+      ENDDO
 
-      FTOP=1.0_JWRB/MAX(TB,EPSMIN)
-      FCUTT=MAX(FR(1),MIN(FTOP,FR(NFRE)))
-      FTOP=MAX(FTOP,FR(NFRE))
+      FTOP = 1.0_JWRB/MAX(TB,EPSMIN)
+      FCUTT = MAX(FR(1),MIN(FTOP,FR(NFRE)))
+      FTOP = MAX(FTOP,FR(NFRE))   !! FTOP is used if a tail contribution is needed
 
-      MCUTB=NINT(LOG10(FCUTB/FR(1))*FLOGSPRDM1)+1
-      MCUTB=MIN(MAX(1,MCUTB),NFRE)
-      DFCUT=0.5_JWRB*MAX(0.0_JWRB,FCUTB-0.5_JWRB*(FR(MAX(1,MCUTB-1))+FR(MCUTB)))
-      DFIMLOC(MCUTB)=MIN(DFCUT*DELTH,DFIM(MCUTB))
-      DFIMLOC(MCUTB)=DFIM(MCUTB)-DFIMLOC(MCUTB)
-
-      MCUTT=NINT(LOG10(FCUTT/FR(1))*FLOGSPRDM1)+1
-      MCUTT=MIN(MAX(1,MCUTT),NFRE)
-      DFCUT=0.5_JWRB*MAX(0.0_JWRB,FCUTT-0.5_JWRB*(FR(MAX(1,MCUTT-1))+FR(MCUTT)))
-      DFIMLOC(MCUTT)=MIN(DFCUT*DELTH,DFIM(MCUTT))
+      MCUTT=NFRE
+!!!!  MCUTT is defined such that the integration will need to be up to frequency FRLOC(MIN(MCUTT+1,NFRE))
+      DO WHILE (FR(MCUTT) > FCUTT .AND. MCUTT > 1 )
+        MCUTT = MCUTT-1
+      ENDDO
 
       IF(FCUTB == FCUTT) MCUTT=MCUTB-1
 
@@ -112,36 +113,86 @@
 !*    2. INTEGRATE OVER FREQUENCIES AND DIRECTION.
 !        -----------------------------------------
 
-      DO M=MCUTB,MCUTT
+!     FREQUENCY SPECTRUM
+      IF (MCUTB > 1) THEN
+        FRLOC(MCUTB-1) = FCUTB
+        WL = (FR(MCUTB) - FCUTB) / (FR(MCUTB) - FR(MCUTB-1))
+        WR = 1.0_JWRB - WL
         K=1
-        DO IJ=KIJS,KIJL
-          TEMP(IJ) = FL1(IJ,K,M)
+        ! Linear interpolation
+        DO IJ = KIJS, KIJL
+          F1D(IJ,MCUTB-1) = ( WL*FL1(IJ,K,MCUTB-1) + WR*FL1(IJ,K,MCUTB) )*DELTH
         ENDDO
-        DO K=2,NANG
-          DO IJ=KIJS,KIJL
-            TEMP(IJ) = TEMP(IJ)+FL1(IJ,K,M)
+        DO K = 2, NANG
+          DO IJ = KIJS, KIJL
+            F1D(IJ,MCUTB-1) = F1D(IJ,MCUTB-1) + ( WL*FL1(IJ,K,MCUTB-1) + WR*FL1(IJ,K,MCUTB) )*DELTH
           ENDDO
         ENDDO
-        DO IJ=KIJS,KIJL
-          EBT(IJ) = EBT(IJ)+DFIMLOC(M)*TEMP(IJ)
+      ENDIF
+
+      DO M = MCUTB, MCUTT
+        FRLOC(M) = FR(M)
+        K=1
+        DO IJ = KIJS, KIJL
+          F1D(IJ,M) = FL1(IJ,K,M)*DELTH
+        ENDDO
+        DO K = 2, NANG
+          DO IJ = KIJS, KIJL
+            F1D(IJ,M) = F1D(IJ,M)+FL1(IJ,K,M)*DELTH
+          ENDDO
         ENDDO
       ENDDO
 
-!     CHECK IF A THE REQUESTED FREQUENCIES ARE ABOVE FR(NFRE)
-      IF ( FBOT < FTOP ) THEN
-
-        ZW = 0.25_JWRB * DELTH * FR5(NFRE) * ( 1.0_JWRB/FBOT**4 - 1.0_JWRB/FTOP**4 )
+      IF (MCUTT < NFRE) THEN
+        FRLOC(MCUTT+1) = FCUTT
+        WL = (FR(MCUTT+1) - FCUTT) / (FR(MCUTT+1) - FR(MCUTT))
+        WR = 1.0_JWRB - WL
         K=1
-        DO IJ=KIJS,KIJL
-          TEMP(IJ) = FL1(IJ,K,NFRE)
+        ! Linear interpolation
+        DO IJ = KIJS, KIJL
+          F1D(IJ,MCUTT+1) = ( WL*FL1(IJ,K,MCUTT) + WR*FL1(IJ,K,MCUTT+1) )*DELTH
         ENDDO
-        DO K=2,NANG
-          DO IJ=KIJS,KIJL
-            TEMP(IJ) = TEMP(IJ)+FL1(IJ,K,NFRE)
+        DO K = 2, NANG
+          DO IJ = KIJS, KIJL
+            F1D(IJ,MCUTT+1) = F1D(IJ,MCUTT+1) + ( WL*FL1(IJ,K,MCUTT) + WR*FL1(IJ,K,MCUTT+1) )*DELTH
           ENDDO
         ENDDO
-        DO IJ=KIJS,KIJL
-          EBT(IJ) = EBT(IJ) + ZW*TEMP(IJ)
+      ENDIF
+
+
+!     TRAPEZOIDAL INTERPOLATION of F1D between FRLOC(MCUTB) and FRLOC(MCUTT)
+      DO M = MAX(MCUTB-1,1), MIN(MCUTT,NFRE-1)
+        DF = 0.5_JWRB*(FRLOC(M+1)-FRLOC(M))
+        DO IJ = KIJS, KIJL
+          EBT(IJ) = EBT(IJ) + DF*(F1D(IJ,M+1)+F1D(IJ,M))
+        ENDDO
+      ENDDO
+
+!     ADD SMALL CONTRIBUTION FOR A LINEAR FRONT TAIL IF NEEDED
+      IF (FCUTB_FT < FCUTB .AND. FCUTB == FR(1)) THEN
+        WL = (FR(1) - FCUTB_FT) / FR(1)
+        WR = 1.0_JWRB - WL
+        DF = 0.5_JWRB * (FR(1) - FCUTB_FT) * (1.0_JWRB + WR)
+        DO IJ = KIJS, KIJL
+          EBT(IJ) = EBT(IJ) + DF*F1D(IJ,1)
+        ENDDO
+      ENDIF
+
+!     CHECK IF A THE REQUESTED FREQUENCIES ARE ABOVE FR(NFRE) (f**-5 extension)
+      IF ( FBOT < FTOP ) THEN
+
+        ZW = 0.25_JWRB * FR5(NFRE) * ( 1.0_JWRB/FBOT**4 - 1.0_JWRB/FTOP**4 )
+        K=1
+        DO IJ = KIJS, KIJL
+          F1D(IJ,NFRE) = FL1(IJ,K,NFRE)*DELTH
+        ENDDO
+        DO K = 2, NANG
+          DO IJ = KIJS, KIJL
+            F1D(IJ,NFRE) = F1D(IJ,NFRE) + FL1(IJ,K,NFRE)*DELTH
+          ENDDO
+        ENDDO
+        DO IJ = KIJS, KIJL
+          EBT(IJ) = EBT(IJ) + ZW*F1D(IJ,NFRE)
         ENDDO
 
       ENDIF 


### PR DESCRIPTION
This PR contains bugfixes for two post-processing routines (sebtmean and se10mean).
The change will **only** affect the **output** of H1012, H1214, H1417, H1721, H2125, H2530 and SH10