### PR TITLE
Update nvhpc CI runners to 25.9

### DIFF
--- a/.github/tools/install-nvhpc.sh
+++ b/.github/tools/install-nvhpc.sh
@@ -79,13 +79,22 @@ echo "+ ${TEMPORARY_FILES}/${FOLDER}/install"
 #rm -rf "${TEMPORARY_FILES}/${FOLDER}"
 
 NVHPC_VERSION=$(basename "${NVHPC_INSTALL_DIR}"/Linux_$(uname -m)/*.*/)
+NVHPC_DIR=${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}
 
 # Use gcc which is available in PATH
-${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin/makelocalrc \
-  -x ${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin \
+${NVHPC_DIR}/compilers/bin/makelocalrc \
+  -x ${NVHPC_DIR}/compilers/bin \
   -gcc $(which gcc) \
   -gpp $(which g++) \
   -g77 $(which gfortran)
+
+# Locate the bundled OpenMPI prefix. From 25.x the comm_libs/mpi symlink points
+# at hpcx (a bin-only directory), so we derive the real prefix from the location
+# of openmpi-default-hostfile and fall back to comm_libs/mpi for older releases.
+MPI_HOME=$(dirname $(dirname $(find ${NVHPC_DIR}/comm_libs -name openmpi-default-hostfile -path '*/etc/*' 2>/dev/null | head -1)))
+if [ -z "${MPI_HOME}" ] || [ ! -d "${MPI_HOME}" ]; then
+    MPI_HOME=${NVHPC_DIR}/comm_libs/mpi
+fi
 
 cat > ${NVHPC_INSTALL_DIR}/env.sh << EOF
 ### Variables
@@ -99,7 +108,7 @@ export NVHPC_LIBRARY_PATH=\${NVHPC_DIR}/compilers/lib
 export LD_LIBRARY_PATH=\${NVHPC_LIBRARY_PATH}
 
 ### MPI
-export MPI_HOME=\${NVHPC_DIR}/comm_libs/mpi
+export MPI_HOME=${MPI_HOME}
 export PATH=\${MPI_HOME}/bin:\${PATH}
 EOF
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,11 @@ jobs:
             compiler_cxx: nvc++
             compiler_fc: nvfortran
             cmake_options: -DCMAKE_CXX_FLAGS=--diag_suppress177
+            # nvc++ 25.9 has a codegen bug where an AVX-512 SCALEFS node is
+            # emitted by an idiom-recognition pass even on non-AVX-512 targets,
+            # causing llc to ICE on some GH runner CPUs. Pin -tp=haswell to
+            # constrain the target features so the pass cannot emit it.
+            dep_eccodes_extra_options: -DCMAKE_CXX_FLAGS=-tp=haswell
             python-version: '3.8'
             caching: true
 
@@ -212,7 +217,7 @@ jobs:
         dependency_cmake_options: |
           ecmwf/fckit: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_FCKIT_VENV=ON"
           ecmwf-ifs/fiat: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_SINGLE_PRECISION=${{ matrix.prec == 'SP' }} -DENABLE_DOUBLE_PRECISION=${{ matrix.prec == 'DP' }} -DENABLE_DR_HOOK_NVTX=OFF"
-          ecmwf/eccodes: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_MEMFS=ON -DENABLE_JPG=OFF -DENABLE_PNG=OFF"
+          ecmwf/eccodes: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_MEMFS=ON -DENABLE_JPG=OFF -DENABLE_PNG=OFF ${{ matrix.dep_eccodes_extra_options }}"
           ecmwf-ifs/field_api: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_ACC=OFF -DENABLE_SINGLE_PRECISION=${{ matrix.prec == 'SP' }} -DENABLE_DOUBLE_PRECISION=${{ matrix.prec == 'DP' }}"
           ecmwf-ifs/loki: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF"
         cmake_options: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_MPI=ON -DENABLE_LOKI=ON -DLOKI_MODE=idem-stack -DENABLE_SINGLE_PRECISION=${{ matrix.prec == 'SP' }} -DENABLE_DOUBLE_PRECISION=${{ matrix.prec == 'DP' }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         name:
           - linux gnu-10
           - linux gnu-14
-          - linux nvhpc-23.5
+          - linux nvhpc-25.9
           - linux intel-classic
           - macos
 
@@ -59,9 +59,9 @@ jobs:
             python-version: '3.11'
             caching: true
 
-          - name: linux nvhpc-23.5
+          - name: linux nvhpc-25.9
             os: ubuntu-22.04
-            compiler: nvhpc-23.5
+            compiler: nvhpc-25.9
             compiler_cc: nvc
             compiler_cxx: nvc++
             compiler_fc: nvfortran
@@ -163,12 +163,13 @@ jobs:
       if: contains( matrix.compiler, 'nvhpc' )
       shell: bash -eux {0}
       run: |
-        ${ECWAM_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc --version 23.5
+        ${ECWAM_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc --version 25.9
         source /opt/nvhpc/env.sh
         echo "${NVHPC_DIR}/compilers/bin"                   >> $GITHUB_PATH
         [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV
         echo "localhost slots=72" >> ${MPI_HOME}/etc/openmpi-default-hostfile
-        echo "ECWAM_LAUNCH_SERIAL_MPI=1" >> $GITHUB_ENV
+        echo "ECWAM_LAUNCH_ARGS=--oversubscribe" >> $GITHUB_ENV
+        echo "ECWAM_LAUNCH_SERIAL_MPI=1"         >> $GITHUB_ENV
 
 
     - name: Install Intel oneAPI compiler

--- a/src/ecwam/CMakeLists.txt
+++ b/src/ecwam/CMakeLists.txt
@@ -506,6 +506,8 @@ if( CMAKE_Fortran_COMPILER_ID MATCHES Intel )
   set_source_files_properties( propconnect.F90 PROPERTIES COMPILE_OPTIONS "-fp-model;strict" )
   set_source_files_properties( stresso.F90 PROPERTIES COMPILE_OPTIONS "-fp-model;strict" )
 elseif( CMAKE_Fortran_COMPILER_ID MATCHES GNU )
+  # TODO: This is only needed due to a known bug in the vectorization characteristics of GNU 15, and should
+  # fixed in GNU 16. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118955 for more information.
   set_source_files_properties( sdice3.F90 PROPERTIES COMPILE_OPTIONS "-fdisable-ipa-simdclone" )
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC" AND CMAKE_BUILD_TYPE MATCHES "Bit")
   set_source_files_properties(


### PR DESCRIPTION
This PR upgrades the nvhpc CI runners to version 25.9.