### PR TITLE
Loki new seed policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
           ecmwf/fckit@refs/tags/0.13.0
           ecmwf-ifs/fiat
           ecmwf-ifs/field_api@refs/tags/v0.3.4
-          ecmwf-ifs/loki@refs/tags/0.3.2
+          ecmwf-ifs/loki@refs/heads/main
         dependency_branch: develop
         dependency_cmake_options: |
           ecmwf/fckit: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_FCKIT_VENV=ON"

--- a/package/bundle/bundle.yml
+++ b/package/bundle/bundle.yml
@@ -40,7 +40,7 @@ projects :
 
     - loki :
         git     : https://github.com/ecmwf-ifs/loki
-        version : 0.3.2
+        version : main
         optional: true
         require : ecbuild
         cmake   : >

--- a/src/ecwam/ecwam_loki.config
+++ b/src/ecwam/ecwam_loki.config
@@ -113,50 +113,93 @@ block = ['ec_parkind', 'parkind_wave',
 
 # add inline function calls here to force the plan to add them
 [routines.chnkmin]
+  seed_routine = true
 [routines.ns_gc]
+  seed_routine = true
 [routines.stress_gc]
+  seed_routine = true
 [routines.transf_snl]
+  seed_routine = true
 [routines.transf]
+  seed_routine = true
 [routines.aki_ice]
+  seed_routine = true
 [routines.aki]
+  seed_routine = true
 [routines.transf_r]
+  seed_routine = true
 [routines.transf_bfi]
+  seed_routine = true
 [routines.peakfri]
+  seed_routine = true
 
 # we add loki inlined routines here to force them to be created
 [routines.femeanws]
+  seed_routine = true
 [routines.scosfl]
+  seed_routine = true
 [routines.frcutindex]
+  seed_routine = true
 [routines.omegagc]
+  seed_routine = true
 [routines.tau_phi_hf]
+  seed_routine = true
 [routines.stresso]
+  seed_routine = true
 [routines.wsigstar]
+  seed_routine = true
 [routines.sinput]
+  seed_routine = true
 [routines.sinput_ard]
+  seed_routine = true
 [routines.taut_z0]
+  seed_routine = true
 [routines.airsea]
+  seed_routine = true
 [routines.femean]
+  seed_routine = true
 [routines.meansqs_lf]
+  seed_routine = true
 [routines.halphap]
+  seed_routine = true
 [routines.wnfluxes]
+  seed_routine = true
 [routines.sdiwbk]
+  seed_routine = true
 [routines.sbottom]
+  seed_routine = true
 [routines.fkmean]
+  seed_routine = true
 [routines.imphftail]
+  seed_routine = true
 [routines.setice]
+  seed_routine = true
 [routines.stokestrn]
+  seed_routine = true
 [routines.stokesdrift]
+  seed_routine = true
 [routines.semean]
+  seed_routine = true
 [routines.sdepthlim]
+  seed_routine = true
 [routines.sinflx]
+  seed_routine = true
 [routines.sdissip_ard]
+  seed_routine = true
 [routines.sdissip]
+  seed_routine = true
 [routines.peak_ang]
+  seed_routine = true
 [routines.sdice]
+  seed_routine = true
 [routines.sdice1]
+  seed_routine = true
 [routines.sdice2]
+  seed_routine = true
 [routines.sdice3]
+  seed_routine = true
 [routines.icebreak_modify_attenuation]
+  seed_routine = true
 
 # Define indices and bounds for array dimensions
 [dimensions.horizontal]

--- a/src/ecwam/ecwam_loki_gpu.config
+++ b/src/ecwam/ecwam_loki_gpu.config
@@ -205,50 +205,93 @@ block = ['ec_parkind', 'parkind_wave', 'yowdrvtype',
 
 # add inline function calls here to force the plan to add them
 [routines.chnkmin]
+  seed_routine = true 
 [routines.ns_gc]
+  seed_routine = true
 [routines.stress_gc]
+  seed_routine = true
 [routines.transf_snl]
+  seed_routine = true
 [routines.transf]
+  seed_routine = true
 [routines.aki_ice]
+  seed_routine = true
 [routines.aki]
+  seed_routine = true
 [routines.transf_r]
+  seed_routine = true
 [routines.transf_bfi]
+  seed_routine = true
 
 # we add loki inlined routines here to force them to be created
 [routines.peakfri]
+  seed_routine = true
 [routines.scosfl]
+  seed_routine = true
 [routines.femeanws]
+  seed_routine = true
 [routines.frcutindex]
+  seed_routine = true
 [routines.omegagc]
+  seed_routine = true
 [routines.tau_phi_hf]
+  seed_routine = true
 [routines.stresso]
+  seed_routine = true
 [routines.wsigstar]
+  seed_routine = true
 [routines.sinput]
+  seed_routine = true
 [routines.sinput_ard]
+  seed_routine = true
 [routines.taut_z0]
+  seed_routine = true
 [routines.airsea]
+  seed_routine = true
 [routines.femean]
+  seed_routine = true
 [routines.wnfluxes]
+  seed_routine = true
 [routines.sdiwbk]
+  seed_routine = true
 [routines.sbottom]
+  seed_routine = true
 [routines.fkmean]
+  seed_routine = true
 [routines.imphftail]
+  seed_routine = true
 [routines.setice]
+  seed_routine = true
 [routines.stokestrn]
+  seed_routine = true
 [routines.stokesdrift]
+  seed_routine = true
 [routines.semean]
+  seed_routine = true
 [routines.sdepthlim]
+  seed_routine = true
 [routines.sinflx]
+  seed_routine = true
 [routines.sdissip_ard]
+  seed_routine = true
 [routines.sdissip]
+  seed_routine = true
 [routines.peak_ang]
+  seed_routine = true
 [routines.halphap]
+  seed_routine = true
 [routines.meansqs_lf]
+  seed_routine = true
 [routines.sdice]
+  seed_routine = true
 [routines.sdice1]
+  seed_routine = true
 [routines.sdice2]
+  seed_routine = true
 [routines.sdice3]
+  seed_routine = true
 [routines.icebreak_modify_attenuation]
+  seed_routine = true
 
 # Disable replication for modules containing global variables
 [routines.yowaltas]

--- a/src/ecwam/ecwam_propags2_loki.config
+++ b/src/ecwam/ecwam_propags2_loki.config
@@ -50,6 +50,7 @@ replicate = true
 
 # Define entry point for call-tree transformation
 [routines.propags2]
+  seed_routine = true
   role = "kernel"
   expand = false
   replicate = false


### PR DESCRIPTION
Loki PR: https://github.com/ecmwf-ifs/loki/pull/698

### Description

This pull request updates the configuration files for ECWAM and related components to ensure that a set of routines are always included ("seeded") in the build plan by explicitly setting the `seed_routine = true` property. This change affects both CPU and GPU configuration files, as well as the `propags2` routine, and is likely intended to guarantee that these routines are generated and available for use, possibly to address issues with inlining or routine omission during code generation.

The most important changes are:

**Routine seeding for ECWAM (CPU and GPU):**
* Added `seed_routine = true` to a comprehensive list of routines in `ecwam_loki.config` to force their inclusion in the build plan.
* Added `seed_routine = true` to the corresponding routines in `ecwam_loki_gpu.config` for GPU builds.

**Routine seeding for propagation kernel:**
* Set `seed_routine = true` for the `propags2` routine in `ecwam_propags2_loki.config` to ensure it is always generated as an entry point.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 