### PR TITLE
README: Remove outdated CLA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,5 +283,3 @@ Contributions to ecWAM are welcome.
 In order to do so, please open a [GitHub issue](https://github.com/ecmwf-ifs/ecwam/issues) where
 a feature request or bug can be discussed.
 Then create a [pull request](https://github.com/ecmwf-ifs/ecwam/pulls) with your contribution.
-All contributors to the pull request need to sign the
-[contributors license agreement (CLA)](https://bol-claassistant.ecmwf.int/ecmwf-ifs/ecwam).


### PR DESCRIPTION
CLA is automatically being linked via PR template.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 