### PR TITLE
Small CI cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,22 +32,12 @@ jobs:
         build_type: [Bit]
         prec: ['DP', 'SP']
         name:
-          - linux gnu-10
           - linux gnu-14
           - linux nvhpc-25.9
           - linux intel-classic
           - macos
 
         include:
-
-          - name: linux gnu-10
-            os: ubuntu-22.04
-            compiler: gnu-10
-            compiler_cc: gcc-10
-            compiler_cxx: g++-10
-            compiler_fc: gfortran-10
-            python-version: '3.8'
-            caching: true
 
           - name: linux gnu-14
             os: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,7 @@ jobs:
       fail-fast: false  # false: try to complete all jobs
 
       matrix:
-        #build_type: [Release,Debug] # Debug tests takes too long
-        build_type: [Release]
+        build_type: [Bit]
         prec: ['DP', 'SP']
         name:
           - linux gnu-10


### PR DESCRIPTION
This PR applies the following cleanup to the CI:

- Change build type from Release to Bit, bringing it inline with the default build type in bundle builds and ifs coupled builds
- Removes the CI entry for GNU 10, which by this point is a very outdated compiler

Future PRs will also add support for Intel ifx and flang to the CI.